### PR TITLE
Fix let chain usage for stable Rust

### DIFF
--- a/collector/src/binance/mod.rs
+++ b/collector/src/binance/mod.rs
@@ -18,59 +18,60 @@ fn handle(
     throttler: &Throttler,
 ) -> Result<(), ConnectorError> {
     let j: serde_json::Value = serde_json::from_str(data.as_str())?;
-    if let Some(j_data) = j.get("data")
-        && let Some(j_symbol) = j_data
+    if let Some(j_data) = j.get("data") {
+        let j_symbol = j_data
             .as_object()
             .ok_or(ConnectorError::FormatError)?
-            .get("s")
-    {
-        let symbol = j_symbol.as_str().ok_or(ConnectorError::FormatError)?;
-        if let Some(e) = j_data.get("e") {
-            let ev = e.as_str().ok_or(ConnectorError::FormatError)?;
-            if ev == "depthUpdate" {
-                let u = j_data
-                    .get("u")
-                    .ok_or(ConnectorError::FormatError)?
-                    .as_i64()
-                    .ok_or(ConnectorError::FormatError)?;
-                #[allow(non_snake_case)]
-                let U = j_data
-                    .get("U")
-                    .ok_or(ConnectorError::FormatError)?
-                    .as_i64()
-                    .ok_or(ConnectorError::FormatError)?;
-                let prev_u = prev_u_map.get(symbol);
-                if prev_u.is_none() || U != *prev_u.unwrap() + 1 {
-                    warn!(%symbol, "missing depth feed has been detected.");
-                    let symbol_ = symbol.to_string();
-                    let writer_tx_ = writer_tx.clone();
-                    let mut throttler_ = throttler.clone();
-                    tokio::spawn(async move {
-                        match throttler_.execute(fetch_depth_snapshot(&symbol_)).await {
-                            Some(Ok(data)) => {
-                                let recv_time = Utc::now();
-                                let _ = writer_tx_.send((recv_time, symbol_, data));
+            .get("s");
+        if let Some(j_symbol) = j_symbol {
+            let symbol = j_symbol.as_str().ok_or(ConnectorError::FormatError)?;
+            if let Some(e) = j_data.get("e") {
+                let ev = e.as_str().ok_or(ConnectorError::FormatError)?;
+                if ev == "depthUpdate" {
+                    let u = j_data
+                        .get("u")
+                        .ok_or(ConnectorError::FormatError)?
+                        .as_i64()
+                        .ok_or(ConnectorError::FormatError)?;
+                    #[allow(non_snake_case)]
+                    let U = j_data
+                        .get("U")
+                        .ok_or(ConnectorError::FormatError)?
+                        .as_i64()
+                        .ok_or(ConnectorError::FormatError)?;
+                    let prev_u = prev_u_map.get(symbol);
+                    if prev_u.is_none() || U != *prev_u.unwrap() + 1 {
+                        warn!(%symbol, "missing depth feed has been detected.");
+                        let symbol_ = symbol.to_string();
+                        let writer_tx_ = writer_tx.clone();
+                        let mut throttler_ = throttler.clone();
+                        tokio::spawn(async move {
+                            match throttler_.execute(fetch_depth_snapshot(&symbol_)).await {
+                                Some(Ok(data)) => {
+                                    let recv_time = Utc::now();
+                                    let _ = writer_tx_.send((recv_time, symbol_, data));
+                                }
+                                Some(Err(error)) => {
+                                    error!(
+                                        symbol = symbol_,
+                                        ?error,
+                                        "couldn't fetch the depth snapshot."
+                                    );
+                                }
+                                None => {
+                                    warn!(
+                                        symbol = symbol_,
+                                        "Fetching the depth snapshot is rate-limited."
+                                    )
+                                }
                             }
-                            Some(Err(error)) => {
-                                error!(
-                                    symbol = symbol_,
-                                    ?error,
-                                    "couldn't fetch the depth snapshot."
-                                );
-                            }
-                            None => {
-                                warn!(
-                                    symbol = symbol_,
-                                    "Fetching the depth snapshot is rate-limited."
-                                )
-                            }
-                        }
-                    });
+                        });
+                    }
+                    *prev_u_map.entry(symbol.to_string()).or_insert(0) = u;
                 }
-                *prev_u_map.entry(symbol.to_string()).or_insert(0) = u;
             }
+            let _ = writer_tx.send((recv_time, symbol.to_string(), data.to_string()));
         }
-        let _ = writer_tx.send((recv_time, symbol.to_string(), data.to_string()));
     }
     Ok(())
 }

--- a/collector/src/binancefuturescm/mod.rs
+++ b/collector/src/binancefuturescm/mod.rs
@@ -18,60 +18,61 @@ fn handle(
     throttler: &Throttler,
 ) -> Result<(), ConnectorError> {
     let j: serde_json::Value = serde_json::from_str(data.as_str())?;
-    if let Some(j_data) = j.get("data")
-        && let Some(j_symbol) = j_data
+    if let Some(j_data) = j.get("data") {
+        let j_symbol = j_data
             .as_object()
             .ok_or(ConnectorError::FormatError)?
-            .get("s")
-    {
-        let symbol = j_symbol.as_str().ok_or(ConnectorError::FormatError)?;
-        let ev = j_data
-            .get("e")
-            .ok_or(ConnectorError::FormatError)?
-            .as_str()
-            .ok_or(ConnectorError::FormatError)?;
-        if ev == "depthUpdate" {
-            let u = j_data
-                .get("u")
+            .get("s");
+        if let Some(j_symbol) = j_symbol {
+            let symbol = j_symbol.as_str().ok_or(ConnectorError::FormatError)?;
+            let ev = j_data
+                .get("e")
                 .ok_or(ConnectorError::FormatError)?
-                .as_i64()
+                .as_str()
                 .ok_or(ConnectorError::FormatError)?;
-            let pu = j_data
-                .get("pu")
-                .ok_or(ConnectorError::FormatError)?
-                .as_i64()
-                .ok_or(ConnectorError::FormatError)?;
-            let prev_u = prev_u_map.get(symbol);
-            if prev_u.is_none() || pu != *prev_u.unwrap() {
-                warn!(%symbol, "missing depth feed has been detected.");
-                let symbol_ = symbol.to_string();
-                let writer_tx_ = writer_tx.clone();
-                let mut throttler_ = throttler.clone();
-                tokio::spawn(async move {
-                    match throttler_.execute(fetch_depth_snapshot(&symbol_)).await {
-                        Some(Ok(data)) => {
-                            let recv_time = Utc::now();
-                            let _ = writer_tx_.send((recv_time, symbol_, data));
+            if ev == "depthUpdate" {
+                let u = j_data
+                    .get("u")
+                    .ok_or(ConnectorError::FormatError)?
+                    .as_i64()
+                    .ok_or(ConnectorError::FormatError)?;
+                let pu = j_data
+                    .get("pu")
+                    .ok_or(ConnectorError::FormatError)?
+                    .as_i64()
+                    .ok_or(ConnectorError::FormatError)?;
+                let prev_u = prev_u_map.get(symbol);
+                if prev_u.is_none() || pu != *prev_u.unwrap() {
+                    warn!(%symbol, "missing depth feed has been detected.");
+                    let symbol_ = symbol.to_string();
+                    let writer_tx_ = writer_tx.clone();
+                    let mut throttler_ = throttler.clone();
+                    tokio::spawn(async move {
+                        match throttler_.execute(fetch_depth_snapshot(&symbol_)).await {
+                            Some(Ok(data)) => {
+                                let recv_time = Utc::now();
+                                let _ = writer_tx_.send((recv_time, symbol_, data));
+                            }
+                            Some(Err(error)) => {
+                                error!(
+                                    symbol = symbol_,
+                                    ?error,
+                                    "couldn't fetch the depth snapshot."
+                                );
+                            }
+                            None => {
+                                warn!(
+                                    symbol = symbol_,
+                                    "Fetching the depth snapshot is rate-limited."
+                                )
+                            }
                         }
-                        Some(Err(error)) => {
-                            error!(
-                                symbol = symbol_,
-                                ?error,
-                                "couldn't fetch the depth snapshot."
-                            );
-                        }
-                        None => {
-                            warn!(
-                                symbol = symbol_,
-                                "Fetching the depth snapshot is rate-limited."
-                            )
-                        }
-                    }
-                });
+                    });
+                }
+                *prev_u_map.entry(symbol.to_string()).or_insert(0) = u;
             }
-            *prev_u_map.entry(symbol.to_string()).or_insert(0) = u;
+            let _ = writer_tx.send((recv_time, symbol.to_string(), data.to_string()));
         }
-        let _ = writer_tx.send((recv_time, symbol.to_string(), data.to_string()));
     }
     Ok(())
 }

--- a/collector/src/binancefuturesum/mod.rs
+++ b/collector/src/binancefuturesum/mod.rs
@@ -18,60 +18,61 @@ fn handle(
     throttler: &Throttler,
 ) -> Result<(), ConnectorError> {
     let j: serde_json::Value = serde_json::from_str(data.as_str())?;
-    if let Some(j_data) = j.get("data")
-        && let Some(j_symbol) = j_data
+    if let Some(j_data) = j.get("data") {
+        let j_symbol = j_data
             .as_object()
             .ok_or(ConnectorError::FormatError)?
-            .get("s")
-    {
-        let symbol = j_symbol.as_str().ok_or(ConnectorError::FormatError)?;
-        let ev = j_data
-            .get("e")
-            .ok_or(ConnectorError::FormatError)?
-            .as_str()
-            .ok_or(ConnectorError::FormatError)?;
-        if ev == "depthUpdate" {
-            let u = j_data
-                .get("u")
+            .get("s");
+        if let Some(j_symbol) = j_symbol {
+            let symbol = j_symbol.as_str().ok_or(ConnectorError::FormatError)?;
+            let ev = j_data
+                .get("e")
                 .ok_or(ConnectorError::FormatError)?
-                .as_i64()
+                .as_str()
                 .ok_or(ConnectorError::FormatError)?;
-            let pu = j_data
-                .get("pu")
-                .ok_or(ConnectorError::FormatError)?
-                .as_i64()
-                .ok_or(ConnectorError::FormatError)?;
-            let prev_u = prev_u_map.get(symbol);
-            if prev_u.is_none() || pu != *prev_u.unwrap() {
-                warn!(%symbol, "missing depth feed has been detected.");
-                let symbol_ = symbol.to_string();
-                let writer_tx_ = writer_tx.clone();
-                let mut throttler_ = throttler.clone();
-                tokio::spawn(async move {
-                    match throttler_.execute(fetch_depth_snapshot(&symbol_)).await {
-                        Some(Ok(data)) => {
-                            let recv_time = Utc::now();
-                            let _ = writer_tx_.send((recv_time, symbol_, data));
+            if ev == "depthUpdate" {
+                let u = j_data
+                    .get("u")
+                    .ok_or(ConnectorError::FormatError)?
+                    .as_i64()
+                    .ok_or(ConnectorError::FormatError)?;
+                let pu = j_data
+                    .get("pu")
+                    .ok_or(ConnectorError::FormatError)?
+                    .as_i64()
+                    .ok_or(ConnectorError::FormatError)?;
+                let prev_u = prev_u_map.get(symbol);
+                if prev_u.is_none() || pu != *prev_u.unwrap() {
+                    warn!(%symbol, "missing depth feed has been detected.");
+                    let symbol_ = symbol.to_string();
+                    let writer_tx_ = writer_tx.clone();
+                    let mut throttler_ = throttler.clone();
+                    tokio::spawn(async move {
+                        match throttler_.execute(fetch_depth_snapshot(&symbol_)).await {
+                            Some(Ok(data)) => {
+                                let recv_time = Utc::now();
+                                let _ = writer_tx_.send((recv_time, symbol_, data));
+                            }
+                            Some(Err(error)) => {
+                                error!(
+                                    symbol = symbol_,
+                                    ?error,
+                                    "couldn't fetch the depth snapshot."
+                                );
+                            }
+                            None => {
+                                warn!(
+                                    symbol = symbol_,
+                                    "Fetching the depth snapshot is rate-limited."
+                                )
+                            }
                         }
-                        Some(Err(error)) => {
-                            error!(
-                                symbol = symbol_,
-                                ?error,
-                                "couldn't fetch the depth snapshot."
-                            );
-                        }
-                        None => {
-                            warn!(
-                                symbol = symbol_,
-                                "Fetching the depth snapshot is rate-limited."
-                            )
-                        }
-                    }
-                });
+                    });
+                }
+                *prev_u_map.entry(symbol.to_string()).or_insert(0) = u;
             }
-            *prev_u_map.entry(symbol.to_string()).or_insert(0) = u;
+            let _ = writer_tx.send((recv_time, symbol.to_string(), data.to_string()));
         }
-        let _ = writer_tx.send((recv_time, symbol.to_string(), data.to_string()));
     }
     Ok(())
 }

--- a/collector/src/hyperliquid/http.rs
+++ b/collector/src/hyperliquid/http.rs
@@ -56,10 +56,10 @@ pub async fn connect(
             Some(Ok(Message::Text(text))) => {
                 let recv_time = Utc::now();
 
-                if let Ok(j) = serde_json::from_str::<serde_json::Value>(&text)
-                    && j.get("channel").and_then(|c| c.as_str()) == Some("pong")
-                {
-                    continue;
+                if let Ok(j) = serde_json::from_str::<serde_json::Value>(&text) {
+                    if j.get("channel").and_then(|c| c.as_str()) == Some("pong") {
+                        continue;
+                    }
                 }
 
                 if ws_tx.send((recv_time, text)).is_err() {


### PR DESCRIPTION
## Summary
- replace unstable let chains in the Binance collectors with nested pattern matching so the code builds on stable Rust
- adjust Hyperliquid pong filtering to avoid nightly-only let chain syntax

## Testing
- cargo build -p collector --release

------
https://chatgpt.com/codex/tasks/task_e_68e1510e45b8832bb344446b4d399fc7