### PR TITLE
Add Binance CM data exploration notebook

### DIFF
--- a/docs/binance_cm_data_exploration.ipynb
+++ b/docs/binance_cm_data_exploration.ipynb
@@ -1,0 +1,313 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f357be95",
+   "metadata": {},
+   "source": [
+    "# Binance Coin-Margined Futures Data Exploration\n",
+    "\n",
+    "This notebook demonstrates how to load historical Binance Coin-Margined (CM) futures market data from `/data/binance_cm/` using pandas and create exemplar visualizations for quick exploratory analysis."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee570535",
+   "metadata": {},
+   "source": [
+    "## 1. Environment setup\n",
+    "\n",
+    "We import the core Python libraries used for data manipulation and visualization.\n",
+    "- **pandas**: tabular data handling\n",
+    "- **numpy**: numerical helpers\n",
+    "- **matplotlib**/**seaborn**: charting utilities\n",
+    "- **pathlib**: convenient filesystem navigation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "531edb46",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns\n",
+    "\n",
+    "# Configure plotting aesthetics\n",
+    "sns.set_theme(style='darkgrid', context='talk')\n",
+    "plt.rcParams['figure.figsize'] = (14, 6)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8bc48387",
+   "metadata": {},
+   "source": [
+    "## 2. Locate available market data files\n",
+    "\n",
+    "The dataset directory may contain multiple symbols (e.g., BTCUSDT, ETHUSDT) and multiple file formats (CSV or Parquet).\n",
+    "The snippet below recursively discovers all supported data files so that we can inspect what is available."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "561132aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DATA_DIR = Path('/data/binance_cm')\n",
+    "\n",
+    "if not DATA_DIR.exists():\n",
+    "    raise FileNotFoundError(f'Data directory {DATA_DIR} not found. Ensure the path is mounted inside the environment before running the notebook.')\n",
+    "\n",
+    "# Collect both Parquet and CSV files\n",
+    "parquet_files = sorted(DATA_DIR.rglob('*.parquet'))\n",
+    "csv_files = sorted(DATA_DIR.rglob('*.csv'))\n",
+    "all_files = parquet_files + csv_files\n",
+    "\n",
+    "print(f'Found {len(all_files)} data file(s) under {DATA_DIR}.')\n",
+    "\n",
+    "# Preview the first few entries grouped by symbol\n",
+    "from collections import defaultdict\n",
+    "files_by_symbol = defaultdict(list)\n",
+    "for path in all_files:\n",
+    "    symbol = path.parent.name\n",
+    "    files_by_symbol[symbol].append(path)\n",
+    "\n",
+    "preview = {symbol: paths[:3] for symbol, paths in files_by_symbol.items()}\n",
+    "for symbol, paths in preview.items():\n",
+    "    print(f\"\n",
+    "Symbol: {symbol}\")\n",
+    "    for path in paths:\n",
+    "        print(f\"  - {path.name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b696b82",
+   "metadata": {},
+   "source": [
+    "## 3. Helper to load a symbol's data\n",
+    "\n",
+    "Depending on the file format, we use the appropriate pandas reader. This helper returns a clean, time-indexed DataFrame ready for analysis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0296120",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def load_symbol_data(symbol: str, limit: int | None = None) -> pd.DataFrame:\n",
+    "    symbol_dir = DATA_DIR / symbol\n",
+    "    if not symbol_dir.exists():\n",
+    "        raise FileNotFoundError(f'Could not find directory for symbol {symbol!r} under {DATA_DIR}.')\n",
+    "\n",
+    "    # Prefer parquet (more efficient); fall back to CSV\n",
+    "    files = sorted(symbol_dir.glob('*.parquet'))\n",
+    "    reader = pd.read_parquet\n",
+    "    if not files:\n",
+    "        files = sorted(symbol_dir.glob('*.csv'))\n",
+    "        reader = lambda path: pd.read_csv(path, parse_dates=['timestamp'], index_col=None)\n",
+    "\n",
+    "    if not files:\n",
+    "        raise FileNotFoundError(f'No parquet or CSV files found for symbol {symbol!r}.')\n",
+    "\n",
+    "    frames: list[pd.DataFrame] = []\n",
+    "    rows_loaded = 0\n",
+    "    for path in files:\n",
+    "        df = reader(path)\n",
+    "        # Standardize timestamp parsing\n",
+    "        if 'timestamp' in df.columns:\n",
+    "            df['timestamp'] = pd.to_datetime(df['timestamp'], utc=True, errors='coerce')\n",
+    "        elif 'time' in df.columns:\n",
+    "            df['timestamp'] = pd.to_datetime(df['time'], unit='ms', utc=True, errors='coerce')\n",
+    "        else:\n",
+    "            raise KeyError('Expected a timestamp or time column in the data files.')\n",
+    "\n",
+    "        df = df.set_index('timestamp').sort_index()\n",
+    "        frames.append(df)\n",
+    "\n",
+    "        rows_loaded += len(df)\n",
+    "        if limit is not None and rows_loaded >= limit:\n",
+    "            break\n",
+    "\n",
+    "    data = pd.concat(frames).sort_index()\n",
+    "\n",
+    "    if limit is not None:\n",
+    "        data = data.iloc[:limit]\n",
+    "\n",
+    "    # Forward-fill to reduce missing values for numeric columns\n",
+    "    numeric_cols = data.select_dtypes(include=[np.number]).columns\n",
+    "    data[numeric_cols] = data[numeric_cols].fillna(method='ffill')\n",
+    "\n",
+    "    return data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9bd1501",
+   "metadata": {},
+   "source": [
+    "## 4. Load a sample symbol\n",
+    "\n",
+    "Update `sample_symbol` to any symbol present in your dataset. The code loads and displays key statistics from the first rows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4c1e6d1a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sample_symbol = next(iter(files_by_symbol)) if files_by_symbol else None\n",
+    "if sample_symbol is None:\n",
+    "    raise RuntimeError('No symbols detected. Ensure the dataset directory contains files.')\n",
+    "\n",
+    "cm_df = load_symbol_data(sample_symbol)\n",
+    "cm_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd64295d",
+   "metadata": {},
+   "source": [
+    "### Summary statistics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d965988",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cm_df.describe().T"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9560147c",
+   "metadata": {},
+   "source": [
+    "## 5. Resample to higher timeframes\n",
+    "\n",
+    "High-frequency data can be noisy. We aggregate to 1-minute candles (open, high, low, close) and traded volume to facilitate plotting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ab019742",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "price_candidates = ['price', 'close', 'last_price', 'mark_price']\n",
+    "volume_candidates = ['volume', 'qty', 'quantity', 'base_volume']\n",
+    "\n",
+    "price_col = next((col for col in price_candidates if col in cm_df.columns), None)\n",
+    "volume_col = next((col for col in volume_candidates if col in cm_df.columns), None)\n",
+    "\n",
+    "if price_col is None:\n",
+    "    raise KeyError('Could not identify a price-like column. Please update `price_candidates`.')\n",
+    "if volume_col is None:\n",
+    "    raise KeyError('Could not identify a volume-like column. Please update `volume_candidates`.')\n",
+    "\n",
+    "resampled = cm_df[[price_col, volume_col]].rename(columns={price_col: 'price', volume_col: 'volume'})\n",
+    "resampled = resampled.resample('1min').agg({\n",
+    "    'price': ['first', 'max', 'min', 'last'],\n",
+    "    'volume': 'sum'\n",
+    "}).dropna()\n",
+    "\n",
+    "# Flatten column MultiIndex\n",
+    "resampled.columns = ['open', 'high', 'low', 'close', 'volume']\n",
+    "resampled.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e517b6e",
+   "metadata": {},
+   "source": [
+    "## 6. Visualizations\n",
+    "\n",
+    "We plot both price action and traded volume over time. Adjust the resampling window or columns to suit your analysis needs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f9a7a6cb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(2, 1, sharex=True, figsize=(16, 10))\n",
+    "\n",
+    "resampled['close'].plot(ax=axes[0], color='dodgerblue')\n",
+    "axes[0].set_title(f'{sample_symbol} Close Price (1-minute)')\n",
+    "axes[0].set_ylabel('Price')\n",
+    "\n",
+    "resampled['volume'].plot(ax=axes[1], color='salmon')\n",
+    "axes[1].set_title(f'{sample_symbol} Volume (1-minute)')\n",
+    "axes[1].set_ylabel('Volume')\n",
+    "axes[1].set_xlabel('Timestamp (UTC)')\n",
+    "\n",
+    "plt.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6cf6014e",
+   "metadata": {},
+   "source": [
+    "### Rolling volatility\n",
+    "\n",
+    "Rolling volatility (standard deviation of returns) is a useful diagnostic for regime changes.\n",
+    "Feel free to adjust the window size for your strategy horizon."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8393bc8e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "returns = resampled['close'].pct_change()\n",
+    "rolling_vol = returns.rolling(window=30, min_periods=15).std() * np.sqrt(30)\n",
+    "\n",
+    "ax = rolling_vol.plot(color='mediumseagreen')\n",
+    "ax.set_title(f'{sample_symbol} Rolling Volatility (30-minute window)')\n",
+    "ax.set_ylabel('Volatility (σ)')\n",
+    "ax.set_xlabel('Timestamp (UTC)')\n",
+    "plt.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aae1a901",
+   "metadata": {},
+   "source": [
+    "## 7. Next steps\n",
+    "\n",
+    "- Compare multiple symbols by repeating the workflow for each directory.\n",
+    "- Join with funding-rate or open-interest data to understand market structure.\n",
+    "- Export aggregated DataFrames with `DataFrame.to_parquet()` for downstream backtesting pipelines.\n",
+    "\n",
+    "This notebook can serve as a starting point for deeper feature engineering and signal research on Binance Coin-Margined futures markets."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a Jupyter notebook that demonstrates how to load Binance Coin-Margined futures data from `/data/binance_cm`
- provide helper utilities for discovering files, ingesting data into pandas, and deriving resampled views
- include sample visualizations for price, volume, and rolling volatility to kickstart exploratory analysis

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e15fb46448832bb45506a580ded8d5